### PR TITLE
clip normalized power values greater than 1 to 1

### DIFF
--- a/heatmap/heatmap.py
+++ b/heatmap/heatmap.py
@@ -358,6 +358,8 @@ def rgb_fn(palette, min_z, max_z):
     "palette is a list of tuples, returns a function of z"
     def rgb_inner(z):
         tone = (z - min_z) / (max_z - min_z)
+	if tone > 1:
+		tone = 1
         tone_scaled = int(tone * (len(palette)-1))
         return palette[tone_scaled]
     return rgb_inner


### PR DESCRIPTION
Sometimes due to values of 0 for z, the mapping of normalized dB values to 0->1 (tone variable) will result in a tone value >1. That messes up the index picking from the color palettes because the index will ineveitably be out of the range on the high side. So the script dies.

This is just a quick workaround that clips all normalized power values >1 to 1. With it in place everything plots like you'd expect with no errors. As for fixing the more fundemental issue that causes the normalization to >1 when z=0, I don't know.